### PR TITLE
Small adjustments for changes in `upload` plugin

### DIFF
--- a/src/uploadadapter.js
+++ b/src/uploadadapter.js
@@ -96,13 +96,15 @@ class UploadAdapter {
 	 * Starts the upload process.
 	 *
 	 * @see module:upload/filerepository~UploadAdapter#upload
-	 * @returns {Promise}
+	 * @returns {Promise.<Object>}
 	 */
 	upload() {
-		return new Promise( ( resolve, reject ) => {
-			this._initRequest();
-			this._initListeners( resolve, reject );
-			this._sendRequest();
+		return this.loader.file.then( file => {
+			return new Promise( ( resolve, reject ) => {
+				this._initRequest();
+				this._initListeners( resolve, reject, file );
+				this._sendRequest( file );
+			} );
 		} );
 	}
 
@@ -110,7 +112,6 @@ class UploadAdapter {
 	 * Aborts the upload process.
 	 *
 	 * @see module:upload/filerepository~UploadAdapter#abort
-	 * @returns {Promise}
 	 */
 	abort() {
 		if ( this.xhr ) {
@@ -136,12 +137,13 @@ class UploadAdapter {
 	 * @private
 	 * @param {Function} resolve Callback function to be called when the request is successful.
 	 * @param {Function} reject Callback function to be called when the request cannot be completed.
+	 * @param {File} file File instance to be uploaded.
 	 */
-	_initListeners( resolve, reject ) {
+	_initListeners( resolve, reject, file ) {
 		const xhr = this.xhr;
 		const loader = this.loader;
 		const t = this.t;
-		const genericError = t( 'Cannot upload file:' ) + ` ${ loader.file.name }.`;
+		const genericError = t( 'Cannot upload file:' ) + ` ${ file.name }.`;
 
 		xhr.addEventListener( 'error', () => reject( genericError ) );
 		xhr.addEventListener( 'abort', () => reject() );
@@ -173,11 +175,12 @@ class UploadAdapter {
 	 * Prepares the data and sends the request.
 	 *
 	 * @private
+	 * @param {File} file File instance to be uploaded.
 	 */
-	_sendRequest() {
+	_sendRequest( file ) {
 		// Prepare form data.
 		const data = new FormData();
-		data.append( 'upload', this.loader.file );
+		data.append( 'upload', file );
 		data.append( 'ckCsrfToken', getCsrfToken() );
 
 		// Send request.

--- a/tests/uploadadapter.js
+++ b/tests/uploadadapter.js
@@ -50,7 +50,9 @@ describe( 'CKFinderUploadAdapter', () => {
 		beforeEach( () => {
 			const file = createNativeFileMock();
 			file.name = 'image.jpeg';
-			loaderMock = { file	};
+			loaderMock = {
+				file: Promise.resolve( file )
+			};
 
 			adapter = editor.plugins.get( FileRepository ).createUploadAdapter( loaderMock );
 		} );
@@ -91,15 +93,14 @@ describe( 'CKFinderUploadAdapter', () => {
 					uploaded: 1
 				};
 
-				const promise = adapter.upload()
-					.then( () => {
-						expect( request.url ).to.equal( 'http://example.com' );
-					} );
+				adapter.upload();
 
-				request = sinonXHR.requests[ 0 ];
-				request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( validResponse ) );
+				return loaderMock.file.then( () => {
+					request = sinonXHR.requests[ 0 ];
+					request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( validResponse ) );
 
-				return promise;
+					expect( request.url ).to.equal( 'http://example.com' );
+				} );
 			} );
 
 			it( 'should throw an error on generic request error', () => {
@@ -111,8 +112,10 @@ describe( 'CKFinderUploadAdapter', () => {
 						expect( msg ).to.equal( 'Cannot upload file: image.jpeg.' );
 					} );
 
-				const request = sinonXHR.requests[ 0 ];
-				request.error();
+				loaderMock.file.then( () => {
+					const request = sinonXHR.requests[ 0 ];
+					request.error();
+				} );
 
 				return promise;
 			} );
@@ -132,8 +135,10 @@ describe( 'CKFinderUploadAdapter', () => {
 						expect( msg ).to.equal( 'Foo bar baz.' );
 					} );
 
-				const request = sinonXHR.requests[ 0 ];
-				request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( responseError ) );
+				loaderMock.file.then( () => {
+					const request = sinonXHR.requests[ 0 ];
+					request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( responseError ) );
+				} );
 
 				return promise;
 			} );
@@ -151,8 +156,10 @@ describe( 'CKFinderUploadAdapter', () => {
 						expect( msg ).to.equal( 'Cannot upload file: image.jpeg.' );
 					} );
 
-				const request = sinonXHR.requests[ 0 ];
-				request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( responseError ) );
+				loaderMock.file.then( () => {
+					const request = sinonXHR.requests[ 0 ];
+					request.respond( 200, { 'Content-Type': 'application/json' }, JSON.stringify( responseError ) );
+				} );
 
 				return promise;
 			} );
@@ -168,8 +175,10 @@ describe( 'CKFinderUploadAdapter', () => {
 						expect( request.aborted ).to.be.true;
 					} );
 
-				request = sinonXHR.requests[ 0 ];
-				adapter.abort();
+				loaderMock.file.then( () => {
+					request = sinonXHR.requests[ 0 ];
+					adapter.abort();
+				} );
 
 				return promise;
 			} );
@@ -183,11 +192,13 @@ describe( 'CKFinderUploadAdapter', () => {
 			it( 'should update progress', () => {
 				adapter.upload();
 
-				const request = sinonXHR.requests[ 0 ];
-				request.uploadProgress( { loaded: 4, total: 10 } );
+				return loaderMock.file.then( () => {
+					const request = sinonXHR.requests[ 0 ];
+					request.uploadProgress( { loaded: 4, total: 10 } );
 
-				expect( loaderMock.uploadTotal ).to.equal( 10 );
-				expect( loaderMock.uploaded ).to.equal( 4 );
+					expect( loaderMock.uploadTotal ).to.equal( 10 );
+					expect( loaderMock.uploaded ).to.equal( 4 );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Small adjustments for changes in `upload` plugin.

---

### Additional information

Code and tests adjusted to changes from https://github.com/ckeditor/ckeditor5-upload/issues/87. Should be closed after or together with https://github.com/ckeditor/ckeditor5-upload/pull/88.

~The CI will fail untill https://github.com/ckeditor/ckeditor5-upload/pull/88 will be merged to `master` so it will be good to merge https://github.com/ckeditor/ckeditor5-upload/pull/88 first and then rerun the CI job for this PR to check if it is green.~

The tests were passing earlier and are passing now because `FileLoader` mock is used there. I wonder if we should switch to using real instance 🤔 WDYT?
